### PR TITLE
Add uk data

### DIFF
--- a/src/dataProviders.js
+++ b/src/dataProviders.js
@@ -160,7 +160,7 @@ function dischargeUKEAUrl(site, options) {
     var period = options.period || 'P30D'; //can't use this. Site only provides data from the past month. Has a since date query though.
 
     //This query returns all of the data that they are willing to provide for a site. It is limited to the past month, unfortunately.
-    var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '-flow--i-15_min-m3_s/readings?_sorted';
+    var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '/readings?_sorted';
     //var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '-flow--i-15_min-m3_s/readings?_sorted&_limit=' + measurements;
     return url;
 }

--- a/src/dataProviders.js
+++ b/src/dataProviders.js
@@ -178,6 +178,21 @@ function parsePegelDischarge(returnedData) {
 }
 
 function parseUKEADischarge(returnedData) {
+    output = [];
+    try {
+        var temp = returnedData['items'];
+        temp.forEach(function (d, index, array) {
+            output[index] = [];
+            output[index][0] = new Date(d.dateTime);
+            output[index][1] = +d.value;
+        });
+
+    } catch (error) {
+        console.warn("The UK Environmental Agency did not have data for this site.");
+        console.log(error);
+    } finally {
+        return output;
+    }
 }
 
 function parseUsgsDischarge(returnedData) {

--- a/src/dataProviders.js
+++ b/src/dataProviders.js
@@ -148,8 +148,11 @@ function dischargePegelUrl(site, options) {
 
 function dischargeUKEAUrl(site, options) {
     if (options === undefined || options === null) options = {};
-    var period = options.period || 'P30D';
-    var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '-level-stage-i-15_min-mASD/readings?_sorted&_limit=100';
+    var period = options.period || 'P30D'; //can't use this. Site only provides data from the past month. Has a since date query though.
+
+    //This query returns all of the data that they are willing to provide for a site. It is limited to the past month, unfortunately.
+    var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '-flow--i-15_min-m3_s/readings?_sorted';
+    //var url = 'https://environment.data.gov.uk/flood-monitoring/id/measures/' + site + '-flow--i-15_min-m3_s/readings?_sorted&_limit=' + measurements;
     return url;
 }
 

--- a/src/dataProviders.js
+++ b/src/dataProviders.js
@@ -15,9 +15,9 @@ var providerList = {
         'siteURL': stationsUKEAUrl,
         'siteType': 'json',
         'siteParse': processUKEAStations,
-        'dischargeURL': dischargePegelUrl,
+        'dischargeURL': dischargeUKEAUrl,
         'dischargeType': 'json',
-        'dischargeParse': parsePegelDischarge
+        'dischargeParse': parseUKEADischarge
     },
     'USGS-DV': {
         'name': 'USGS-DV',
@@ -127,9 +127,6 @@ function stationsPegelUrl(options) {
 
 function stationsUKEAUrl(options) {
     if (options === undefined || options === null) options = {};
-    //There is no 'Access-Control-Allow-Origin' header!
-    //return 'https://flood-warning-information.service.gov.uk/flood/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=flood:stations&maxFeatures=10000&outputFormat=application/json&srsName=EPSG:4326';
-    //return 'http://localhost:63342/HydroCloud/resources/UKEAengland.json';
     //This seems like the official request. It seems to have the correct header!
     return 'http://environment.data.gov.uk/flood-monitoring/id/stations?parameter=flow'
 }
@@ -178,6 +175,9 @@ function parsePegelDischarge(returnedData) {
         //TODO: how does PEGELONLINE data indicate bad values?
     });
     return output;
+}
+
+function parseUKEADischarge(returnedData) {
 }
 
 function parseUsgsDischarge(returnedData) {

--- a/src/dataProviders.js
+++ b/src/dataProviders.js
@@ -67,10 +67,18 @@ function processUKEAStations(input) {
     var outCSV = csvHeader + 'Source,STAID,STANAME,DRAIN_SQKM,HUC02,LAT_GAGE,LNG_GAGE\n';
     input = input['items'];
     //console.log(input);
+
+    //The site name needs to include the part of the URL that changes. So, it should look like:
+    //F1906-flow-logged-i-15_min-m3_s
+    //six sites collect more than one type of flow. Taking the first isn't always the best. Still.
+
     input.forEach(function(station, index, array) {
         var tempJSON = {};
         tempJSON['Source'] = 'UKEAengland';
-        tempJSON['STAID'] = station['stationReference'];
+        //tempJSON['STAID'] = station['stationReference'];
+        var stationURL = station['measures'][0]['@id'];
+        var id = stationURL.slice(60);
+        tempJSON['STAID'] = id;
         var river = station['riverName'] || "";
         if (station['riverName']) river += ' at ';
         var site = station['label'];
@@ -80,7 +88,8 @@ function processUKEAStations(input) {
 
         outJSON.push(tempJSON);
 
-        outCSV += 'UKEAengland,' + station['stationReference'] + ',' + river + site + ',null,null,' + station['lat'] + ',' + station['long'] + '\n';
+        //outCSV += 'UKEAengland,' + station['stationReference'] + ',' + river + site + ',null,null,' + station['lat'] + ',' + station['long'] + '\n';
+        outCSV += 'UKEAengland,' + id + ',' + river + site + ',null,null,' + station['lat'] + ',' + station['long'] + '\n';
     });
     //console.dir(outJSON);
     return outCSV;
@@ -128,7 +137,7 @@ function stationsPegelUrl(options) {
 function stationsUKEAUrl(options) {
     if (options === undefined || options === null) options = {};
     //This seems like the official request. It seems to have the correct header!
-    return 'http://environment.data.gov.uk/flood-monitoring/id/stations?parameter=flow'
+    return 'http://environment.data.gov.uk/flood-monitoring/id/stations?parameter=flow';
 }
 
 function stationsUsgsUrl(options) {

--- a/station-list.html
+++ b/station-list.html
@@ -108,6 +108,9 @@
     <li>PEGEL-ONLINE Stream Gages(Germany):
         <button type="button" class="btn btn-xs btn-primary" onclick='downloadButton("PEGELONLINE", {});'>Download CSV of stations</button>
     </li>
+    <li>UK Environment Agency- England (UK):
+        <button type="button" class="btn btn-xs btn-primary" onclick='downloadButton("UKEAengland", {});'>Download CSV of stations</button>
+    </li>
 </ul>
 
 


### PR DESCRIPTION
This closes issue #104. :uk:  :fireworks: 
Unfortunately, the UK Environmental Agency only publishes English data, and a bit of Wales. For the rest of the UK, you need to go to each nation directly. 

Other issues:
- they only make the past month available through this service; 
- they don't collect a lot of discharge, mostly stage; 